### PR TITLE
Fix storybook iframe: add Tailwind CSS to preview build

### DIFF
--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -13,6 +13,15 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {},
   },
+  async viteFinal(config) {
+    const { defineConfig } = await import('vite');
+    return defineConfig({
+      ...config,
+      css: {
+        postcss: './postcss.config.js',
+      },
+    });
+  },
   docs: {
     autodocs: 'tag',
   },

--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import '../src/styles/globals.css';
 
 const preview: Preview = {
   parameters: {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -24,10 +24,12 @@
     "@storybook/test": "^8.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "autoprefixer": "^10.5.0",
     "eslint": "^9.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "storybook": "^8.0.0",
+    "tailwindcss": "^3.4.19",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/storybook/postcss.config.js
+++ b/packages/storybook/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Problem

Storybook's iframe rendered all components **completely unstyled** — Tailwind CSS classes were present in the HTML but had zero CSS applied. The storybook had a `globals.css` with `@tailwind` directives and a `tailwind.config.js`, but the CSS was **never imported** in the preview configuration and Vite had **no PostCSS pipeline** to compile the `@tailwind` directives into actual utility classes.

The result: preview CSS file was 136 bytes (raw `@tailwind` directives, not actual CSS). Components showed as plain unstyled HTML.

## Fix

1. **Import globals.css in `preview.ts`** — this is the entry point for the iframe build
2. **Add `postcss.config.js`** with tailwindcss and autoprefixer plugins
3. **Configure `viteFinal` in `main.ts`** to point to the postcss config, so Vite's CSS pipeline compiles Tailwind directives

## Result

After fix: preview CSS file is **63KB** (compiled Tailwind utility classes). Card component verifies:
- Background: white ✅
- Border radius: 12px (rounded-xl) ✅
- Box shadow: shadow-sm ✅
- Padding: 24px (p-6) ✅